### PR TITLE
Mealplanner ArrayList stuff

### DIFF
--- a/app/src/main/java/com/group4sweng/scranplan/Helper/RecipeHelpers.java
+++ b/app/src/main/java/com/group4sweng/scranplan/Helper/RecipeHelpers.java
@@ -1,0 +1,23 @@
+package com.group4sweng.scranplan.Helper;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+
+public class RecipeHelpers {
+
+    /** Convert original HashMap <String, String> format from Firebase into a readable ArrayList for displaying to the User
+     * @param ingredientHashMap - The ingredientList data from Firebase. A HashMap of two strings.
+     * @return - The ArrayList equivalent to be displayed from the recipe info screen or Mealplanner screen.
+     */
+    public static ArrayList<String> convertToIngredientListFormat(HashMap<String, String> ingredientHashMap){
+        ArrayList<String> ingredientArray = new ArrayList<>();
+
+        for (Map.Entry<String, String> stringStringEntry : ingredientHashMap.entrySet()) {
+            Map.Entry mapElement = stringStringEntry;
+            String string = mapElement.getKey().toString() + ": " + mapElement.getValue().toString();
+            ingredientArray.add(string);
+        }
+        return ingredientArray;
+    }
+}

--- a/app/src/main/java/com/group4sweng/scranplan/MealPlanner/PlannerFragment.java
+++ b/app/src/main/java/com/group4sweng/scranplan/MealPlanner/PlannerFragment.java
@@ -196,6 +196,8 @@ public class PlannerFragment extends Fragment {
             if (resultCode == Activity.RESULT_OK) {
                 Bundle bundle = data.getExtras();
 
+                HashMap<String, String> testMap = (HashMap<String, String>) bundle.getSerializable("ingredientHashMap");
+
                 //Hides menu options
                 sortButton.setVisible(false);
 
@@ -210,6 +212,10 @@ public class PlannerFragment extends Fragment {
                     for (String key : bundle.keySet()) {
                         map.put(key, bundle.get(key));
                     }
+
+                    //  Adds the ingredient Hash Map
+                    HashMap<String, String> ingredientHashMap = (HashMap<String, String>) bundle.getSerializable("ingredientHashMap");
+                    map.put("ingredientHashMap", ingredientHashMap);
 
                     //Sets new listener for inserted recipe to open info fragment
                     currentSelection.setOnClickListener(v -> openRecipeInfo(map));

--- a/app/src/main/java/com/group4sweng/scranplan/MealPlanner/PlannerInfoFragment.java
+++ b/app/src/main/java/com/group4sweng/scranplan/MealPlanner/PlannerInfoFragment.java
@@ -51,6 +51,7 @@ public class PlannerInfoFragment extends RecipeInfoFragment{
         this.recipeDescription = (String) map.get("recipeDescription");
         this.chefName = (String) map.get("chefName");
         this.ingredientArray = (ArrayList<String>) map.get("ingredientList");
+        this.ingredientHashMap = (HashMap<String, String>) map.get("ingredientHashMap");
         this.recipeRating = (String) map.get("rating");
         this.xmlPresentation = (String) map.get("xmlURL");
         this.planner = (Boolean) map.get("planner");
@@ -70,7 +71,6 @@ public class PlannerInfoFragment extends RecipeInfoFragment{
         this.mPescatarian = (Boolean) map.get("pescatarian");
         this.mVegan = (Boolean) map.get("vegan");
         this.mVegetarian = (Boolean) map.get("vegetarian");
-
     }
 
     /*

--- a/app/src/main/java/com/group4sweng/scranplan/RecipeFragment.java
+++ b/app/src/main/java/com/group4sweng/scranplan/RecipeFragment.java
@@ -28,6 +28,7 @@ import com.google.firebase.firestore.DocumentSnapshot;
 import com.google.firebase.firestore.FirebaseFirestore;
 import com.google.firebase.firestore.Query;
 import com.google.firebase.firestore.QuerySnapshot;
+import com.group4sweng.scranplan.Helper.RecipeHelpers;
 import com.group4sweng.scranplan.RecipeInfo.RecipeInfoFragment;
 import com.group4sweng.scranplan.SearchFunctions.HomeQueries;
 import com.group4sweng.scranplan.SearchFunctions.HomeRecyclerAdapter;
@@ -39,7 +40,6 @@ import com.group4sweng.scranplan.UserInfo.UserInfoPrivate;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 /**
  * This class builds the horizontal scrolls of custom preference recipe selection for the user on the
@@ -591,11 +591,8 @@ public class RecipeFragment extends Fragment {
         ArrayList<String> ingredientArray = new ArrayList<>();
         HashMap<String, String> ingredientHashMap = (HashMap<String, String>) document.getData().get("Ingredients");
 
-        for (Map.Entry<String, String> stringStringEntry : ingredientHashMap.entrySet()) {
-            Map.Entry mapElement = stringStringEntry;
-            String string = mapElement.getKey().toString() + ": " + mapElement.getValue().toString();
-            ingredientArray.add(string);
-        }
+        //  Convert the Firebase ingredientList HashMap into a readable ArrayList format that can be displayed to the user.
+        ingredientArray = RecipeHelpers.convertToIngredientListFormat(ingredientHashMap);
 
         //Creating a bundle so all data needed from firestore query snapshot can be passed through into fragment class
         mBundle = new Bundle();

--- a/app/src/main/java/com/group4sweng/scranplan/RecipeFragment.java
+++ b/app/src/main/java/com/group4sweng/scranplan/RecipeFragment.java
@@ -37,7 +37,7 @@ import com.group4sweng.scranplan.SearchFunctions.SearchQuery;
 import com.group4sweng.scranplan.UserInfo.UserInfoPrivate;
 
 import java.util.ArrayList;
-import java.util.Iterator;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -589,18 +589,17 @@ public class RecipeFragment extends Fragment {
 
         //Takes ingredient array from snap shot and reformats before being passed through to fragment
         ArrayList<String> ingredientArray = new ArrayList<>();
+        HashMap<String, String> ingredientHashMap = (HashMap<String, String>) document.getData().get("Ingredients");
 
-        Map<String, Map<String, Object>> test = (Map) document.getData().get("Ingredients");
-        Iterator hmIterator = test.entrySet().iterator();
-
-        while (hmIterator.hasNext()) {
-            Map.Entry mapElement = (Map.Entry) hmIterator.next();
+        for (Map.Entry<String, String> stringStringEntry : ingredientHashMap.entrySet()) {
+            Map.Entry mapElement = stringStringEntry;
             String string = mapElement.getKey().toString() + ": " + mapElement.getValue().toString();
             ingredientArray.add(string);
         }
 
         //Creating a bundle so all data needed from firestore query snapshot can be passed through into fragment class
         mBundle = new Bundle();
+        mBundle.putSerializable("ingredientHashMap", ingredientHashMap);
         mBundle.putStringArrayList("ingredientList", ingredientArray);
         mBundle.putString("recipeID", document.getId());
         mBundle.putString("xmlURL", document.get("xml_url").toString());
@@ -626,7 +625,6 @@ public class RecipeFragment extends Fragment {
 
         ArrayList faves = (ArrayList) document.get("favourite");
         mBundle.putBoolean("isFav", faves.contains(user.getUID().hashCode()));
-
 
         RecipeInfoFragment recipeDialogFragment = new RecipeInfoFragment();
         recipeDialogFragment.setArguments(mBundle);

--- a/app/src/main/java/com/group4sweng/scranplan/RecipeInfo/RecipeInfoFragment.java
+++ b/app/src/main/java/com/group4sweng/scranplan/RecipeInfo/RecipeInfoFragment.java
@@ -39,6 +39,7 @@ import com.group4sweng.scranplan.UserInfo.UserInfoPrivate;
 import com.squareup.picasso.Picasso;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 
 
 public class RecipeInfoFragment extends AppCompatDialogFragment implements FilterType {
@@ -66,6 +67,7 @@ public class RecipeInfoFragment extends AppCompatDialogFragment implements Filte
     protected String xmlPresentation;
     protected String reheat;
     protected ArrayList<String> ingredientArray;
+    protected HashMap<String, String> ingredientHashMap;
     protected Boolean planner;
     protected ArrayList<String> favouriteRecipe;
     protected UserInfoPrivate mUser;
@@ -122,6 +124,7 @@ public class RecipeInfoFragment extends AppCompatDialogFragment implements Filte
         recipeImage = getArguments().getString("imageURL");
         recipeDescription = getArguments().getString("recipeDescription");
         chefName = getArguments().getString("chefName");
+        ingredientHashMap = (HashMap<String, String>) getArguments().getSerializable("ingredientHashMap");
         ingredientArray = getArguments().getStringArrayList("ingredientList");
         recipeRating = getArguments().getString("rating");
         xmlPresentation = getArguments().getString("xmlURL");
@@ -202,6 +205,7 @@ public class RecipeInfoFragment extends AppCompatDialogFragment implements Filte
         recipeImage = bundle.getString("imageURL");
         recipeDescription = bundle.getString("recipeDescription");
         chefName = bundle.getString("chefName");
+
         ingredientArray = bundle.getStringArrayList("ingredientList");
         recipeRating = bundle.getString("rating");
         xmlPresentation = bundle.getString("xmlURL");

--- a/app/src/main/java/com/group4sweng/scranplan/RecipeInfo/RecipeInfoFragment.java
+++ b/app/src/main/java/com/group4sweng/scranplan/RecipeInfo/RecipeInfoFragment.java
@@ -207,6 +207,7 @@ public class RecipeInfoFragment extends AppCompatDialogFragment implements Filte
         chefName = bundle.getString("chefName");
 
         ingredientArray = bundle.getStringArrayList("ingredientList");
+        ingredientHashMap = (HashMap<String, String>) bundle.getSerializable("ingredientHashMap");
         recipeRating = bundle.getString("rating");
         xmlPresentation = bundle.getString("xmlURL");
         planner = bundle.getBoolean("planner");


### PR DESCRIPTION
Fixed issue where info on the HashMap contents of the ingredients wasn't being passed to the Mealplanner, instead only an arraylist equivalent was being sent. Now both are sent and a helper function for converting between the 2 has been included in RecipeHelpers.

```
/** Convert original HashMap <String, String> format from Firebase into a readable ArrayList for displaying to the User
     * @param ingredientHashMap - The ingredientList data from Firebase. A HashMap of two strings.
     * @return - The ArrayList equivalent to be displayed from the recipe info screen or Mealplanner screen.
     */
    public static ArrayList<String> convertToIngredientListFormat(HashMap<String, String> ingredientHashMap){
        ArrayList<String> ingredientArray = new ArrayList<>();

        for (Map.Entry<String, String> stringStringEntry : ingredientHashMap.entrySet()) {
            Map.Entry mapElement = stringStringEntry;
            String string = mapElement.getKey().toString() + ": " + mapElement.getValue().toString();
            ingredientArray.add(string);
        }
        return ingredientArray;
    }
```
